### PR TITLE
Updated YAML formatting in k3slogs.yaml

### DIFF
--- a/k8s/k3slogs.yaml
+++ b/k8s/k3slogs.yaml
@@ -1,6 +1,7 @@
 clusterName: YOURCLUSTERHERE
-splunkObservability.realm: YOURREALMHERE        
-splunkObservability.accessToken: YOURTOKENHERE
+splunkObservability:
+  realm: YOURREALMHERE
+  accessToken: YOURTOKENHERE
 
 fluentd:
   config:


### PR DESCRIPTION
Just a small update to the YAML file for the Chart upgrade values.  Prior to this change, this command...

```
helm upgrade splunk-otel-collector-XXXXX --values k3slogs.yaml splunk-otel-collector-chart/splunk-otel-collector
```

...will return this error:
```
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
splunk-otel-collector:
- (root): Additional property splunkObservability.accessToken is not allowed
- (root): Additional property splunkObservability.realm is not allowed
```