### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@
 # Welcome to the Splunk Observability OpenTelemetry Workshop
 
 To get started, please proceed to [The Splunk Observability OpenTelemetry Workshop Homepage](https://signalfx.github.io/otelworkshop/).
+
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.