### PR TITLE
Updates to docs and config files after validation testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Use ```deploy.sh``` to deploy when you have completed your changes.
 cd otelworkshop
 python3 -m venv venv
 source venv/bin/activate
-pip3 install -r docs/doc-tols/requirements.txt
+pip3 install -r docs/doc-tools/requirements.txt
 ```
 
 ## Each new session setup

--- a/docs/apm/host/java.md
+++ b/docs/apm/host/java.md
@@ -50,11 +50,11 @@ In the `run-client.sh` script the java command:
 ```bash
 java \
 -Dexec.executable="java" \
--Dotel.resource.attributes=service.name=java-otel-client,deployment.environment=apm-workshop \
+-Dsplunk.metrics.enabled=false \
 -javaagent:/opt/splunk-otel-javaagent.jar \
 -jar ./target/java-app-1.0-SNAPSHOT.jar
 ```
 
-The `splunk-otel-javaagent.jar` file is the automatic OpenTelemetry instrumentation that will emit spans from the app. No code changes are necessary! The `otel.` resources set up the service name Aand environment. Config details can be found [here](https://docs.splunk.com/Observability/gdi/get-data-in/application/java/configuration/advanced-java-otel-configuration.html)
+The `splunk-otel-javaagent.jar` file is the automatic OpenTelemetry instrumentation that will emit spans from the app. No code changes are necessary! The `otel.` resources set up the service name and environment. Config details can be found [here](https://docs.splunk.com/Observability/gdi/get-data-in/application/java/configuration/advanced-java-otel-configuration.html)
 
 Splunk's OpenTelmetry autoinstrumentation for Java is [here](https://github.com/signalfx/splunk-otel-java)

--- a/host/java/run-client.sh
+++ b/host/java/run-client.sh
@@ -1,5 +1,13 @@
+# The following environment variables would apply an attribute to all spans emitted
+# from the application.  In the workshop, we apply this tag to all Spans via the Collector
+# configuration and therefore don't need to set it at the application layer.
 #export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=apm-workshop
+
+# This environment variable defines the location of the Span receiver.  The address below is the default
+# value for the Java instrumentation and therefore doesn't need to be explicitly set.  It's provided here
+# reference.
 #export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317
+
 export OTEL_SERVICE_NAME=java-otel-client
 
 java \

--- a/k8s/collectorconfig/k8s-pod-metrics.yaml
+++ b/k8s/collectorconfig/k8s-pod-metrics.yaml
@@ -3,7 +3,7 @@ splunkObservability:
   realm: YOURREALMHERE
   accessToken: YOURTOKENHERE
 
-otelAgent:
+agent:
   config:
     processors:
       resource/add_environment:

--- a/k8s/collectorconfig/metricstransform.yaml
+++ b/k8s/collectorconfig/metricstransform.yaml
@@ -1,11 +1,19 @@
-clusterName: YOURCLUSTERHERE
-splunkObservability:
-  realm: YOURREALMHERE
-  accessToken: YOURTOKENHERE
-
-otelAgent:
+agent:
   config:
+    receivers:
+      prometheus_simple:
+        endpoint: prometheus:9090
     processors:
+      attributes/update:
+        actions:
+          - action: update
+            key: my.key
+            value: redacted
+      resource/add_environment:
+        attributes:
+          - action: insert
+            key: deployment.environment
+            value: <ENV PREFIX>-apm-workshop
       metricstransform/prometheus_simple:
         transforms:
           - include: CustomGauge
@@ -13,10 +21,26 @@ otelAgent:
             new_name: TransformedGauge
     service:
       pipelines:
+        traces:
+          processors:
+            - memory_limiter
+            - k8s_tagger
+            - batch
+            - resource
+            - resourcedetection
+            - attributes/update
+            - resource/add_environment
         metrics:
+          receivers:
+            - hostmetrics
+            - kubeletstats
+            - receiver_creator
+            - signalfx
+            - prometheus_simple
           processors:
             - memory_limiter
             - batch
             - resource
             - resourcedetection
+            - resource/add_environment
             - metricstransform/prometheus_simple

--- a/k8s/collectorconfig/otel-logging-exporter.yaml
+++ b/k8s/collectorconfig/otel-logging-exporter.yaml
@@ -3,7 +3,7 @@ splunkObservability:
   realm: YOURREALMHERE
   accessToken: YOURTOKENHERE
 
-otelAgent:
+agent:
   config:
     exporters:
       logging:

--- a/k8s/collectorconfig/otel-prometheus.yaml
+++ b/k8s/collectorconfig/otel-prometheus.yaml
@@ -3,8 +3,6 @@ agent:
     receivers:
       prometheus_simple:
         endpoint: "prometheus:9090"
-#     prometheus_simple2:
-#       endpoint: "prometheus2:9090"
     service:
       pipelines:
         metrics:
@@ -14,4 +12,3 @@ agent:
             - receiver_creator
             - signalfx
             - prometheus_simple
- #          - prometheus_simple2

--- a/k8s/collectorconfig/otel-redis.yaml
+++ b/k8s/collectorconfig/otel-redis.yaml
@@ -3,7 +3,7 @@ splunkObservability:
   realm: YOURREALMHERE
   accessToken: YOURTOKENHERE
 
-otelAgent:
+agent:
   config:
     receivers:
       smartagent/redis:    

--- a/k8s/collectorconfig/spanprocessor.yaml
+++ b/k8s/collectorconfig/spanprocessor.yaml
@@ -9,4 +9,11 @@ agent:
     service:
       pipelines:
         traces:
-          processors: [memory_limiter, k8s_tagger, batch, resource, resourcedetection, attributes/update]
+          processors:
+            - memory_limiter,
+            - k8s_tagger,
+            - batch,
+            - resource,
+            - resourcedetection,
+            - attributes/update
+            - resource/add_environment

--- a/k8s/dotnet/dotnet-deployment.yaml
+++ b/k8s/dotnet/dotnet-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     - name: SIGNALFX_SERVICE_NAME
       value: dotnet5-httpget
     - name: SIGNALFX_ENV
-      value: apm-workshop
+      value: <ENV PREFIX>-apm-workshop
     - name: CORECLR_ENABLE_PROFILING
       value: "1"
     - name: CORECLR_PROFILER

--- a/k8s/dotnet/test.yaml
+++ b/k8s/dotnet/test.yaml
@@ -18,7 +18,7 @@ spec:
     - name: SIGNALFX_SERVICE_NAME
       value: dotnet5-httpget
     - name: SIGNALFX_ENV
-      value: apm-workshop
+      value: <ENV PREFIX>-apm-workshop
     - name: CORECLR_ENABLE_PROFILING
       value: "1"
     - name: CORECLR_PROFILER

--- a/k8s/dotnet21/dotnet-2.1-deployment.yaml
+++ b/k8s/dotnet21/dotnet-2.1-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     - name: SIGNALFX_ENDPOINT_URL
       value: "http://$(SPLUNK_OTEL_AGENT):9411/api/v2/spans"
     - name: SIGNALFX_TRACE_GLOBAL_TAGS
-      value: deployment.environment:apm-workshop
+      value: deployment.environment:<ENV PREFIX>-apm-workshop
     - name: SIGNALFX_TRACE_DEBUG
       value: "true"
     - name: SIGNALFX_TRACE_LOG_PATH

--- a/k8s/dotnet21/test.yaml
+++ b/k8s/dotnet21/test.yaml
@@ -18,7 +18,7 @@ spec:
     - name: SIGNALFX_ENDPOINT_URL
       value: "http://$(SPLUNK_OTEL_AGENT):9411/api/v2/spans"
     - name: SIGNALFX_TRACE_GLOBAL_TAGS
-      value: deployment.environment:apm-workshop
+      value: deployment.environment:<ENV PREFIX>-apm-workshop
     - name: SIGNALFX_TRACE_DEBUG
       value: "true"
     - name: SIGNALFX_TRACE_LOG_PATH

--- a/k8s/istio/flask-deployment-istio.yaml
+++ b/k8s/istio/flask-deployment-istio.yaml
@@ -23,7 +23,7 @@ spec:
             containerPort: 5000
         env:
         - name: OTEL_RESOURCE_ATTRIBUTES
-          value: deployment.environment=apm-workshop
+          value: deployment.environment=<ENV PREFIX>-apm-workshop
         - name: OTEL_SERVICE_NAME
           value: server-flask-otel-k8s
         - name: OTEL_PROPAGATORS

--- a/k8s/istio/storage/requests-client.yaml
+++ b/k8s/istio/storage/requests-client.yaml
@@ -10,7 +10,7 @@ spec:
     image: docker.io/stevelsplunk/splk-python
     env:
     - name: OTEL_RESOURCE_ATTRIBUTES
-      value: deployment.environment=apm-workshop
+      value: deployment.environment=<ENV PREFIX>-apm-workshop
     - name: OTEL_SERVICE_NAME
       value: client-py
     - name: SPLUNK_OTEL_AGENT

--- a/k8s/java-deployment.yaml
+++ b/k8s/java-deployment.yaml
@@ -12,6 +12,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.hostIP
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: service.name=client-java-otel-k8s
     - name: SPLUNK_METRICS_ENABLED
       value: "true"
     - name: SPLUNK_METRICS_ENDPOINT

--- a/k8s/java/manual-inst/java-reqs-manual-inst.yaml
+++ b/k8s/java/manual-inst/java-reqs-manual-inst.yaml
@@ -15,7 +15,7 @@ spec:
         fieldRef:
           fieldPath: status.hostIP
     - name: OTEL_RESOURCE_ATTRIBUTES
-      value: service.name=manualinst-java-otel-k8s,deployment.environment=apm-workshop
+      value: service.name=manualinst-java-otel-k8s
     - name: SPLUNK_METRICS_ENDPOINT
       value: http://$(SPLUNK_OTEL_AGENT):9943
     - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/k8s/java/tools/java-deployment-sa.yaml
+++ b/k8s/java/tools/java-deployment-sa.yaml
@@ -12,7 +12,7 @@ spec:
         fieldRef:
           fieldPath: status.hostIP
     - name: OTEL_RESOURCE_ATTRIBUTES
-      value: service.name=client-java-otel-k8s,deployment.environment=apm-workshop
+      value: service.name=client-java-otel-k8s,deployment.environment=<ENV PREFIX>-apm-workshop
     - name: SPLUNK_METRICS_ENDPOINT
       value: http://$(SPLUNK_OTEL_AGENT):9943
     - name: OTEL_EXPORTER_JAEGER_ENDPOINT

--- a/k8s/python/tools/py-deployment-sa.yaml
+++ b/k8s/python/tools/py-deployment-sa.yaml
@@ -21,7 +21,7 @@ spec:
             containerPort: 5000
         env:
         - name: OTEL_RESOURCE_ATTRIBUTES
-          value: deployment.environment=apm-workshop
+          value: deployment.environment=<ENV PREFIX>-apm-workshop
         - name: OTEL_SERVICE_NAME
           value: server-flask-otel-k8s
         - name: SPLUNK_OTEL_AGENT
@@ -59,7 +59,7 @@ spec:
     image: docker.io/stevelsplunk/splk-python
     env:
     - name: OTEL_RESOURCE_ATTRIBUTES
-      value: deployment.environment=apm-workshop
+      value: deployment.environment=<ENV PREFIX>-apm-workshop
     - name: OTEL_SERVICE_NAME
       value: client-py-otel-k8s
     - name: SPLUNK_OTEL_AGENT

--- a/k8s/resource-environment.yaml
+++ b/k8s/resource-environment.yaml
@@ -1,0 +1,16 @@
+agent:
+  config:
+    processors:
+      resource/add_environment:
+        attributes:
+          - action: insert
+            value: <ENV PREFIX>-apm-workshop
+            key: deployment.environment
+    service:
+      pipelines:
+        traces:
+          processors:
+            - memory_limiter
+            - batch
+            - resourcedetection
+            - resource/add_environment

--- a/k8s/tools/java-deployment2.yaml
+++ b/k8s/tools/java-deployment2.yaml
@@ -13,7 +13,7 @@ spec:
         fieldRef:
           fieldPath: status.hostIP
     - name: OTEL_RESOURCE_ATTRIBUTES
-      value: service.name=client2-java-otel-k8s,deployment.environment=apm-workshop
+      value: service.name=client2-java-otel-k8s,deployment.environment=<ENV PREFIX>-apm-workshop
     - name: SPLUNK_METRICS_ENABLED
       value: "true"
     - name: SPLUNK_METRICS_ENDPOINT


### PR DESCRIPTION
After extensive testing on Bill G's merged branch, I added some additional tweaks to make it easier work through the content.  The most notable changes after Bill's updates are:

* Minor update to the `CONTRIBUTING.md` steps to correct a typo
* Removing all references to Application-based `deployment.environment` tags.  Environment is now all set at the Collector level
* String templating to allow a `grep | sed` command to quickly update all K8s configuration files to set the same APM Environment. [Line Reference here](https://github.com/signalfx/otelworkshop/compare/main...tjohander-splunk:otelworkshop:tsj-validation-updates?expand=1#diff-7d5db95fc3e300e141476b624baaeacb1810ccaa7241d97c87f95bf277429e03R159)
* Various Otel Collector config exercises' Helm values files are built additively.  In other words, each values file incorporates the previous exercises list of Processors, Receivers and Pipeline values.  The way the Helm chart works is that the list elements in these Collector config keys are overwritten, rather than added to.  `--resuse-values` does not preserve elements in the lists of these Collector keys. 
* Steve Lerner's work on .NET, Istio, etc... have largely remain untested and unchanged, outside of the Environment prefix replacement.  Validating and "operationalizing" the content for .NET and Istio will be covered in future PRs.