### PR TITLE
updating multipass installation command

### DIFF
--- a/docs/apm/k8s/prep.md
+++ b/docs/apm/k8s/prep.md
@@ -54,7 +54,7 @@ brew --version
 We will use [Multipass](https://multipass.run) as a hypervisor for Mac:
 
 ```bash
-brew cask install multipass
+brew install multipass --cask
 ```
 
 If needed, further instructions are [here](https://multipass.run/docs/installing-on-macos). Do one final brew upgrade before spinning up VM:

--- a/docs/apm/workshop-steps/prep.md
+++ b/docs/apm/workshop-steps/prep.md
@@ -56,7 +56,7 @@ brew --version
 We will use [Multipass](https://multipass.run) as a hypervisor for Mac:
 
 ```bash
-brew cask install multipass
+brew install multipass --cask
 ```
 
 If needed, further instructions are [here](https://multipass.run/docs/installing-on-macos). Do one final brew upgrade before spinning up VM:


### PR DESCRIPTION
On running the existing command (`brew cask install multipass`), you get this error:
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead. This PR updates the multipass installation command with brew to the correct one.